### PR TITLE
Fix Problem in Double.DoTryParse

### DIFF
--- a/Source/Floats.pas
+++ b/Source/Floats.pas
@@ -37,19 +37,19 @@ type
     class method IsNegativeInfinity(Value: Single): Boolean;
 
     method &Equals(other: Single): Boolean;
-    begin 
+    begin
       exit other = self;
     end;
 
     method CompareTo(a: Object): Integer;
-    begin 
-      if a is Single then 
+    begin
+      if a is Single then
         exit CompareTo(Single(a));
       exit CompareTo(Convert.ToSingle(a));
     end;
 
     method CompareTo(a: Single): Integer;
-    begin 
+    begin
       if self < a then exit -1;
       if self > a then exit 1;
       if self = a then exit 0;
@@ -84,7 +84,7 @@ type
     method ToString: String; override;
     method ToString(aLocale: Locale): String;
     method ToString(aNumberOfDecimalDigits: UInt32): String; inline;
-    method ToString(aNumberOfDecimalDigits: UInt32; aLocale: Locale): String; 
+    method ToString(aNumberOfDecimalDigits: UInt32; aLocale: Locale): String;
     class method Parse(s: String): Double;
     class method Parse(s: String; aLocale: Locale): Double;
     class method TryParse(s: String; out Value: Double): Boolean;
@@ -103,21 +103,21 @@ type
     class method IsPositiveInfinity(Value: Double): Boolean;
     class method IsNegativeInfinity(Value: Double): Boolean;
 
-    
+
     method &Equals(other: Double): Boolean;
-    begin 
+    begin
       exit other = self;
     end;
 
     method CompareTo(a: Object): Integer;
-    begin 
-      if a is Double then 
+    begin
+      if a is Double then
         exit CompareTo(Double(a));
       exit CompareTo(Convert.ToDouble(a));
     end;
 
     method CompareTo(a: Double): Integer;
-    begin 
+    begin
       if self < a then exit -1;
       if self > a then exit 1;
       if self = a then exit 0;
@@ -251,12 +251,12 @@ end;
 
 class method Double.DoTryParse(s: String; aLocale: Locale; out Value: Double; aRaiseOverflowException: Boolean): Boolean;
 begin
-  exit Convert.TryParseDouble(s, out Value, aRaiseOverflowException);
+  exit Convert.TryParseDouble(s, aLocale, out Value, aRaiseOverflowException);
 end;
 
 method Single.ToString: String;
 begin
-  exit ToString(Locale.Current);  
+  exit ToString(Locale.Current);
 end;
 
 method Single.ToString(aLocale: Locale): String;
@@ -458,7 +458,7 @@ begin
     var ldata : array[0..maxpos] of Byte;
     ldata[0] := 1;
     ldata[1] := 0;
-    memcpy(@ldata[2], @data[1], maxpos-1);    
+    memcpy(@ldata[2], @data[1], maxpos-1);
     data := ldata;
     inc(exponent);
     is_fraction_present := False;
@@ -513,7 +513,7 @@ begin
       var ldata : array[0..maxpos] of Byte;
       ldata[0] := 1;
       ldata[1] := 0;
-      memcpy(@ldata[2], @data[1], maxpos-1);    
+      memcpy(@ldata[2], @data[1], maxpos-1);
       data := ldata;
       inc(exponent);
       is_fraction_present := False;
@@ -647,7 +647,7 @@ begin
   end;
   {$ENDREGION}
 
-  {$REGION process .#### } 
+  {$REGION process .#### }
   var t_orig:= lValue mod 1;
   if (t_orig <> 0) and (cur_position < maxpos) then begin
     var fl:= true;
@@ -675,12 +675,12 @@ begin
     var ldata : array[0..maxpos+1] of Byte;
     ldata[0] := 1;
     ldata[1] := 0;
-    memcpy(@ldata[2], @data[1], maxpos-1);    
+    memcpy(@ldata[2], @data[1], maxpos-1);
     data := ldata;
-    inc(exp);    
+    inc(exp);
     inc(nexp);
   end;
-*)  
+*)
   var buf:= new array of Char(nexp + aNumberOfDecimalDigits + 2) ;
   var bufpos:= 0;
   if not is_positive_value then begin

--- a/Tests/Double_Parse.pas
+++ b/Tests/Double_Parse.pas
@@ -11,11 +11,14 @@ type
     method doTest(aValue: Double);
     begin
       Assert.AreEqual(aValue.ToString(fLocale), Double.Parse(aValue.ToString(fLocale), fLocale).ToString(fLocale));
+
+     // Check.AreEqual(aValue.ToString, Double.Parse(aValue.ToString).ToString);
+
     end;
 
     method doTest2(aStrValue: String;aValue: Double);
     begin
-      Assert.AreEqual(aValue.ToString(fLocale), Double.Parse(aStrValue, fLocale).ToString(fLocale));
+      Assert.AreEqual(aValue.ToString(Locale.Invariant), Double.Parse(aStrValue, Locale.Invariant).ToString(Locale.Invariant));
     end;
 
     method doTest3(aValue: Double);
@@ -28,7 +31,8 @@ type
 
     method SetupTest; override;
     begin
-      fLocale := new Locale(Locale.Invariant.PlatformLocale);
+      //fLocale := new Locale(Locale.Invariant.PlatformLocale);
+      fLocale := new Locale(Locale.Current.PlatformLocale);
     end;
 
 
@@ -77,7 +81,7 @@ type
 
     method doTest2(aStrValue: String;aValue: Single);
     begin
-      Assert.AreEqual(aValue.ToString(fLocale), Single.Parse(aStrValue, fLocale).ToString(fLocale));
+      Assert.AreEqual(aValue.ToString(Locale.Invariant), Single.Parse(aStrValue, Locale.Invariant).ToString(Locale.Invariant));
     end;
 
     method doTest3(aValue: Single);
@@ -90,7 +94,8 @@ type
 
     method SetupTest; override;
     begin
-      fLocale := new Locale(Locale.Invariant.PlatformLocale);
+     // fLocale := new Locale(Locale.Invariant.PlatformLocale);
+      fLocale := new Locale(Locale.Current.PlatformLocale);
     end;
 
 


### PR DESCRIPTION
call to
Convert.TryParseDouble(s, out Value, aRaiseOverflowException);
was wrong! Must be
exit Convert.TryParseDouble(s, aLocale, out Value, aRaiseOverflowException);

Fixed Tests to use Locale.Invariant where needed for Test