### PR TITLE
Change behavior of SubString

### DIFF
--- a/Source/String.pas
+++ b/Source/String.pas
@@ -389,10 +389,10 @@ end;
 
 method String.Substring(StartIndex: Integer; aLength: Integer): not nullable String;
 begin
+  if aLength = 0 then exit '';
   CheckIndex(StartIndex);
   if aLength > 1 then
     CheckIndex(StartIndex+aLength-1);
-  if aLength = 0 then exit '';
   if (StartIndex = 0) and (aLength = self.Length) then exit self;
   {$HIDE W46}
   exit String.FromPChar(@(@fFirstChar)[StartIndex], aLength);

--- a/Tests/Island.Tests.Shared.projitems
+++ b/Tests/Island.Tests.Shared.projitems
@@ -17,5 +17,6 @@
     <Compile Include="$(MSBuildThisFileDirectory)String_Trim.pas" />
     <Compile Include="$(MSBuildThisFileDirectory)Math_Power.pas" />
     <Compile Include="$(MSBuildThisFileDirectory)TextConvert_utf_tests.pas" />
+    <Compile Include="$(MSBuildThisFileDirectory)String_Substring.pas" />
   </ItemGroup>
 </Project>

--- a/Tests/Island.Tests.Windows.sln
+++ b/Tests/Island.Tests.Windows.sln
@@ -1,6 +1,8 @@
 
 Microsoft Visual Studio Solution File, Format Version 12.00
-# RemObjects Fire
+# RemObjects Water
+Project("{656346D9-4656-40DA-A068-22D5425D4639}") = "Island.Tests.Shared", "Island.Tests.Shared.elements", "{8BC0E3A8-C6B3-4FCC-AC6B-D80EE04F2628}"
+EndProject
 Project("{656346D9-4656-40DA-A068-22D5425D4639}") = "Island.Tests.Windows", "Island.Tests.Windows.elements", "{768B2414-B89A-492C-B5A9-2115A89B557C}"
 EndProject
 Global

--- a/Tests/String_Substring.pas
+++ b/Tests/String_Substring.pas
@@ -1,0 +1,36 @@
+﻿namespace Elements.RTL2.Tests.Shared;
+
+uses
+  RemObjects.Elements.EUnit;
+
+type
+  String_SubString = public class(Test)
+  public
+
+    method Substring;
+    begin
+      var sStart := '012345678901234';
+      var l := sStart.Length;
+      Assert.AreEqual(l, 15);
+      // First Char
+      var s := sStart.Substring(0,1);
+      Assert.AreEqual(s, '0');
+
+      // Last Char
+      s := sStart.Substring(14,1);
+      Assert.AreEqual(s, '4');
+
+     //count 0 should be empty Char
+      s := sStart.Substring(14,0);
+      Assert.AreEqual(s, '');
+
+    //count 0 should be empty Char and not crash
+    // Net and Delphi will simply resturn a empty String
+      s := sStart.Substring(15,0);
+      Assert.AreEqual(s, '');
+
+    end;
+
+  end;
+
+end.


### PR DESCRIPTION
method String.Substring(StartIndex: Integer; aLength: Integer): not nullable String;

If aLength = 0 it should return a Empty String to match NET and Delphi