### PR TITLE
LLVM optimised math: Ensure build ifdefs exactly match Elements and EBuild

### DIFF
--- a/Source/Math.PurePascal.pas
+++ b/Source/Math.PurePascal.pas
@@ -5,7 +5,7 @@ namespace RemObjects.Elements.System;
 // (WebAssembly, Android, mobile Darwin platforms, unsupported architectures)
 
 // Check same conditions as Math.pas - must be kept in sync!
-{$IF ((WINDOWS AND (i386 OR x86_64 OR ARM64)) OR ((DARWIN AND NOT (IOS OR TVOS OR WATCHOS OR VISIONOS)) AND (i386 OR x86_64 OR ARM64)) OR ((LINUX AND NOT ANDROID) AND (i386 OR x86_64 OR ARM64)))}
+{$IF (WINDOWS AND (i386 OR x86_64 OR ARM64)) OR (DARWIN AND NOT (IOS OR TVOS OR WATCHOS OR VISIONOS))}
   {$DEFINE USE_LLVM_MATH_VECTORLIB}
 {$ENDIF}
 

--- a/Source/Math.pas
+++ b/Source/Math.pas
@@ -8,9 +8,9 @@ interface
 // Two implementations available:
 //   1. Math.LLVMVectorLib.pas - SLEEF-based (ENABLED for supported platforms)
 //   2. Math.PurePascal.pas    - Pure Pascal fallback
-// Supported: Windows (), macOS (ARM), Linux (non-Android) on i386, x86_64, ARM64
+// Supported: Windows (i386, x86_64, ARM64), macOS (x86_64, ARM64)
 // You MUST keep this up to date with Elements' IslandOutput.pas, ShouldUseVectorMathLib()
-{$IF ((WINDOWS AND (i386 OR x86_64 OR ARM64)) OR ((DARWIN AND NOT (IOS OR TVOS OR WATCHOS OR VISIONOS)) AND (i386 OR x86_64 OR ARM64)) OR ((LINUX AND NOT ANDROID) AND (i386 OR x86_64 OR ARM64)))}
+{$IF (WINDOWS AND (i386 OR x86_64 OR ARM64)) OR (DARWIN AND NOT (IOS OR TVOS OR WATCHOS OR VISIONOS))}
   {$DEFINE USE_LLVM_MATH_VECTORLIB}  // Uses SLEEF library with LLVM vectorization
 {$ENDIF}
 


### PR DESCRIPTION
The build error: https://remobjects.slack.com/archives/C0250BVCW/p1764517386554229

> Build for 20251130-152429-elements-develop failed. Error Action: script | function compile | function compileIsland | function runEBuild | ebuild.runCustomEBuild | ebuild(Source/IslandRTL/Source/Island.sln --debug "--setting:IslandSDKFolder=c:\CI\b\elements\937\Island\SD...): 'Error: E:                   Duplicate method "class method Acos(d: Double): Double" with same signature [c:\CI\b\elements\937\Source\IslandRTL\Source\Math.PurePascal.pas (20)]'.

This seems to be macOS:

> Source file: c:\CI\b\elements\937\Source\IslandRTL\Source\VersionHelpers.pas
>                   Reference: c:\CI\b\elements\937\Island\GC\Darwin\macOS\x86_64\gc.fx
>                   Reference: c:\CI\b\elements\937\Island\SDKs\Darwin\macOS 26.0\CoreFoundation.fx
>                   Reference: c:\CI\b\elements\937\Island\SDKs\Darwin\macOS 26.0\Foundation.fx
>                   Reference: c:\CI\b\elements\937\Island\SDKs\Darwin\macOS 26.0\rtl.fx
>                   -> Phase Resolving Bodies, Device-x86_64 started.
> E:                   Duplicate method "class method Acos(d: Double): Double" with same signature [c:\CI\b\elements\937\Source\IslandRTL\Source\Math.PurePascal.pas (20)]
> N:                   Previous declaration was here [c:\CI\b\elements\937\Source\IslandRTL\Source\Math.LLVMVectorLib.pas (79)]
> E:                   Duplicate method "class method Asin(d: Double): Double" with same signature [c:\CI\b\elements\937\Source\IslandRTL\Source\Math.PurePascal.pas (21)]
> N:                   Previous declaration was here [c:\CI\b\elements\937\Source\IslandRTL\Source\Math.LLVMVectorLib.pas (81)]
> E:                   Duplicate method "class method Atan(d: Double): Double" with same signature [c:\CI\b\elements\937\Source\IslandRTL\Source\Math.PurePascal.pas (22)]
> N:                   Previous declaration was here [c:\CI\b\elements\937\Source\IslandRTL\Source\Math.LLVMVectorLib.pas (83)]
> E:                   Duplicate method "class method Atan2(x: Double; y: Double): Double" with same signature [c:\CI\b\elements\937\Source\IslandRTL\Source\Math.PurePascal.pas (23)]
> N:                   Previous declaration was here [c:\CI\b\elements\937\Source\IslandRTL\Source\Math.LLVMVectorLib.pas (85)]
> E:                   Duplicate method "class method Ceiling(d: Double): Double" with same signature [c:\CI\b\elements\937\Source\IslandRTL\Source\Math.PurePascal.pas (24)]
> N:                   Previous declaration was here [c:\CI\b\elements\937\Source\IslandRTL\Source\Math.LLVMVectorLib.pas (87)]

But how? I simplified the version conditionals, which had grown as I had picked and excluded some CPU architectured. I am not confident this solves it; I'm really puzzled.

