### PR TITLE
E27512: IslandMath is used only for Windows and macOS

### DIFF
--- a/Source/Math.LLVMVectorLib.pas
+++ b/Source/Math.LLVMVectorLib.pas
@@ -64,7 +64,7 @@
 // NOT supported: Linux, iOS, tvOS, watchOS, visionOS, Android, WebAssembly
 
 // Check same conditions as Math.pas - must be kept in sync!
-{$IF WINDOWS OR (DARWIN AND MACOS) OR ((LINUX AND NOT ANDROID) AND (i386 OR x86_64 OR ARM64))}
+{$IF WINDOWS OR (DARWIN AND MACOS)}
   {$DEFINE USE_LLVM_MATH_VECTORLIB}
 {$ENDIF}
 

--- a/Source/Math.PurePascal.pas
+++ b/Source/Math.PurePascal.pas
@@ -5,7 +5,7 @@
 // (WebAssembly, Android, mobile Darwin platforms, unsupported architectures)
 
 // Check same conditions as Math.pas - must be kept in sync!
-{$IF WINDOWS OR (DARWIN AND MACOS) OR ((LINUX AND NOT ANDROID) AND (i386 OR x86_64 OR ARM64))}
+{$IF WINDOWS OR (DARWIN AND MACOS)}
   {$DEFINE USE_LLVM_MATH_VECTORLIB}
 {$ENDIF}
 

--- a/Source/Math.pas
+++ b/Source/Math.pas
@@ -9,11 +9,12 @@ interface
 //   1. Math.LLVMVectorLib.pas - SLEEF-based (ENABLED for supported platforms)
 //   2. Math.PurePascal.pas    - Pure Pascal fallback
 //
-// Supported: Windows ( i386, x86_64, arm64), macOS (x86_64, arm64), Linux (non-Android) on i386, x86_64, arm64
+// Supported: Windows (i386, x86_64, arm64), macOS (x86_64, arm64)
+// NOT supported: Linux, iOS, tvOS, watchOS, visionOS, Android, WebAssembly
 // You MUST keep this up to date with Elements' IslandOutput.pas, ShouldUseVectorMathLib()
 
 // Check same conditions as Math.pas - must be kept in sync!
-{$IF WINDOWS OR (DARWIN AND MACOS) OR ((LINUX AND NOT ANDROID) AND (i386 OR x86_64 OR ARM64))}
+{$IF WINDOWS OR (DARWIN AND MACOS)}
   {$DEFINE USE_LLVM_MATH_VECTORLIB}  // Uses SLEEF library with LLVM vectorization
 {$ENDIF}
 


### PR DESCRIPTION
The ifdefs were incorrect and out of sync with the other code using IslandMath. It is for Windows and macOS only currently. This caused IslandRTL code to try to link to it on Linux, incorrectly.